### PR TITLE
Remove references to the demo.eclipse-pass.org environment

### DIFF
--- a/about.html
+++ b/about.html
@@ -87,7 +87,7 @@
                 PASS is an open source software project. We welcome collaboration with other institutions who share our goals. <a href="contact.html">Contact our team</a> for more information, or take a look at our code base, available on <a href="https://github.com/eclipse-pass/main">GitHub</a>.
               </p>
               <p>
-                Try the <a href="demo.html">demo now</a> or <a href="contact.html">contact us</a> about deploying Eclipse PASS at your institution.
+                See the <a href="demo.html">demo now</a> or <a href="contact.html">contact us</a> about deploying Eclipse PASS at your institution.
               </p>
             </div>
           </div>

--- a/demo.html
+++ b/demo.html
@@ -92,15 +92,14 @@
           <div style="max-width:1000px;" class="col-12">
             <h1 class="font-weight-light mt-5">Eclipse PASS Demo</h1>
             <p class="my-4">
-              A demo instance of Eclipse PASS is available. The following is a walk-through of a typical submission workflow:
+              The following is a walk-through of a typical submission workflow in PASS:
             </p>
             <div class="embed-responsive embed-responsive-16by9">
               <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/5gLAyFgd0ek" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
             <p class="mt-5 mb-0">
-              You can find instructions on how to use the demo instance <a href="https://github.com/eclipse-pass/main/blob/main/docs/user/README.md">here</a>. Interested in running pass at your institution? <a href="contact.html">Contact us!</a>
+              Interested in seeing a live demo or running PASS at your institution? <a href="contact.html">Contact us!</a>
             </p>
-            <a href="https://demo.eclipse-pass.org/login/saml" class="btn btn-primary my-3 pl-4 pr-4 ember-view">Use the Demo</a>
           </div>
         </div>
       </div>

--- a/faq.html
+++ b/faq.html
@@ -100,7 +100,7 @@
             <a id="who-can-use" class="who-can-use-pass"></a>
             <h3>Who can use PASS?</h3>
             <p>
-              PASS is designed to be used by any organization needing to meet public access policy requirements. The Eclipse Foundation intends to deploy a public multi-tenant instance for general use. In addition, the PASS open source project is designed to be deployable by any organization that wants to run their own instance. Currently, while PASS is under active development, The Eclipse Foundation has a demo instance deployed at <a href="https://demo.eclipse-pass.org">demo.eclipse-pass.org</a>.
+              PASS is designed to be used by any organization needing to meet public access policy requirements. The PASS open source project is designed to be deployable by any organization that wants to run their own instance.
             </p>
           </section>
           <section>

--- a/faq.html
+++ b/faq.html
@@ -100,7 +100,7 @@
             <a id="who-can-use" class="who-can-use-pass"></a>
             <h3>Who can use PASS?</h3>
             <p>
-              PASS is designed to be used by any organization needing to meet public access policy requirements. The PASS open source project is designed to be deployable by any organization that wants to run their own instance.
+              PASS is designed to be used by any organization needing to meet public access policy requirements. The PASS open source project is also designed to be deployable by any organization that wants to run their own instance.
             </p>
           </section>
           <section>


### PR DESCRIPTION
This PR removes the references to the `demo.eclipse-pass.org` site.  A decision has been made to decommission the demo site, so we are removing documentation references before shutting the environment down.